### PR TITLE
Update benchmarks to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.6"
 
 [dev-dependencies]
 criterion = "0.3.0"
-tokio = "0.2.10"
+tokio = {version="0.2.21", features = ["rt-core"] }
 
 [[example]]
 name = "raw-simple"

--- a/src/async_channel.rs
+++ b/src/async_channel.rs
@@ -217,7 +217,7 @@ mod test {
         assert_eq!(subscriber2.get_receiver_id(), 10001);
         assert_eq!(subscriber3.get_receiver_id(), 10002);
 
-        let (publisher2, subscriber4): (async_channel::Publisher<usize>, async_channel::Subscriber<usize>) =
+        let (_publisher2, subscriber4): (async_channel::Publisher<usize>, async_channel::Subscriber<usize>) =
             super::bounded(10, 2);
         let subscriber5 = subscriber4.clone();
         let subscriber6 = subscriber4.clone();


### PR DESCRIPTION
Refresh the benchmark code to be compatible with v0.2.0 of the API and tokio v0.2.21