### PR TITLE
bug: update crossbeam-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 arc-swap = "0.4.2"
 futures = { version = "^0.3.1" }
-crossbeam-channel = "0.3.9"
+crossbeam-channel = "0.5.4"
 log = "0.4.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Impact

The affected version of this crate's the bounded channel incorrectly assumes that Vec::from_iter has allocated capacity that same as the number of iterator elements. Vec::from_iter does not actually guarantee that and may allocate extra memory. The destructor of the bounded channel reconstructs Vec from the raw pointer based on the incorrect assumes described above. This is unsound and causing deallocation with the incorrect capacity when Vec::from_iter has allocated different sizes with the number of iterator elements.

Patches

This has been fixed in crossbeam-channel 0.4.4.


References
See crossbeam-rs/crossbeam#533, crossbeam-rs/crossbeam#539, and rustsec/advisory-db#425 for more details.