### PR TITLE
bug: update tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.6"
 
 [dev-dependencies]
 criterion = "0.3.0"
-tokio = {version="0.2.21", features = ["rt-core"] }
+tokio = {version="1.19.2", features = ["rt", "rt-multi-thread"] }
 
 [[example]]
 name = "raw-simple"


### PR DESCRIPTION
THe current tokio version has a race condition bug.
This update resolves the issue in CVE-2021-45710 (though it only affected
benchmark code)