### PR TITLE
docs: update to version 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_broadcast_channel"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Filip Dulic <filip.dulic@gmail.com>", "Vladan Popovic <vladanovic@gmail.com>", "Bojan Petrovic <bojan_petrovic@fastmail.fm>", "The Tari Development Community"]
 description = "Bounded non-blocking single-producer-multi-consumer broadcast channel"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
This update fixes some security issues and updates some dependencies.
There are also some minor housekeeping updates.

Although the API has not changed, this update bumps the minor version
number in case the switch to stable Rust or dependency changes resulted in unexpected upstream
issues.

## Main changes:

#### Update tokio version

This update resolves the issue in CVE-2021-45710 (though it only affected benchmark code)

#### Fix clippy hints

There were a small number of clippy lints to be resolved.
Clippy will result in hard errors in CI in future.

#### Update crossbeam

Reolves CVE-2020-15254

Brings linting rules in line with the main Tari repo

#### Switch to using stable rust

This repo now uses stable Rust by default.
The CI workflows were updated accordingly.